### PR TITLE
Enable webrtc workbench use

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -12,7 +12,7 @@ config_version=5
 
 config/name="Godot Golf"
 run/main_scene="res://scenes/main.tscn"
-config/features=PackedStringArray("4.2", "Forward Plus")
+config/features=PackedStringArray("4.3", "Forward Plus")
 config/icon="res://icon.svg"
 
 [autoload]
@@ -34,27 +34,27 @@ left_mouse={
 }
 left={
 "deadzone": 0.5,
-"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":65,"key_label":0,"unicode":97,"echo":false,"script":null)
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":65,"key_label":0,"unicode":97,"location":0,"echo":false,"script":null)
 ]
 }
 right={
 "deadzone": 0.5,
-"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":68,"key_label":0,"unicode":100,"echo":false,"script":null)
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":68,"key_label":0,"unicode":100,"location":0,"echo":false,"script":null)
 ]
 }
 down={
 "deadzone": 0.5,
-"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":83,"key_label":0,"unicode":115,"echo":false,"script":null)
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":83,"key_label":0,"unicode":115,"location":0,"echo":false,"script":null)
 ]
 }
 up={
 "deadzone": 0.5,
-"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":87,"key_label":0,"unicode":119,"echo":false,"script":null)
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":87,"key_label":0,"unicode":119,"location":0,"echo":false,"script":null)
 ]
 }
 scoreboard={
 "deadzone": 0.5,
-"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194306,"key_label":0,"unicode":0,"echo":false,"script":null)
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194306,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
 ]
 }
 

--- a/scenes/UI/multiplayer_menu.tscn
+++ b/scenes/UI/multiplayer_menu.tscn
@@ -1,9 +1,10 @@
-[gd_scene load_steps=5 format=3 uid="uid://d3soqqlkvvbbp"]
+[gd_scene load_steps=6 format=3 uid="uid://d3soqqlkvvbbp"]
 
 [ext_resource type="Script" path="res://scripts/gui/multiplayer_menu.gd" id="1_7u6sm"]
 [ext_resource type="PackedScene" uid="uid://w6qkohd2ejme" path="res://scenes/golfball.tscn" id="2_52pmy"]
 [ext_resource type="Theme" uid="uid://cui388khn2ihv" path="res://themes/menu_theme.tres" id="4_0icmm"]
 [ext_resource type="Texture2D" uid="uid://dgnyfhw1yvvt1" path="res://assets/images/godot_golf_logo.png" id="4_o1rfd"]
+[ext_resource type="PackedScene" uid="uid://cfmoahalri06d" path="res://addons/player-networking/NetworkGateway.tscn" id="5_pirhu"]
 
 [node name="MultiplayerMenu" type="Control"]
 layout_mode = 3
@@ -78,6 +79,21 @@ text = "Singleplayer"
 layout_mode = 2
 text = "Multiplayer"
 
+[node name="HBoxWebRTC" type="HBoxContainer" parent="SingleplayerMultiplayerContainer"]
+layout_mode = 2
+
+[node name="WebRTC" type="Button" parent="SingleplayerMultiplayerContainer/HBoxWebRTC"]
+layout_mode = 2
+text = "WebRTC network"
+
+[node name="Label" type="Label" parent="SingleplayerMultiplayerContainer/HBoxWebRTC"]
+layout_mode = 2
+text = "Roomname:"
+
+[node name="LineEdit" type="LineEdit" parent="SingleplayerMultiplayerContainer/HBoxWebRTC"]
+layout_mode = 2
+text = "Tokyo"
+
 [node name="MultiplayerContainer" type="VBoxContainer" parent="."]
 visible = false
 layout_mode = 1
@@ -111,8 +127,18 @@ placeholder_text = "Insert host-IP"
 layout_mode = 2
 text = "Join"
 
+[node name="NetworkGateway" parent="." instance=ExtResource("5_pirhu")]
+layout_mode = 0
+offset_left = 283.0
+offset_top = 476.0
+offset_right = 921.0
+offset_bottom = 773.0
+
 [connection signal="pressed" from="NameSelectionContainer/NameConfirmButton" to="." method="_on_name_confirm_button_pressed"]
 [connection signal="pressed" from="SingleplayerMultiplayerContainer/HBoxContainer/SingleplayerButton" to="." method="_on_singleplayer_button_pressed"]
 [connection signal="pressed" from="SingleplayerMultiplayerContainer/HBoxContainer/MultiplayerButton" to="." method="_on_multiplayer_button_pressed"]
+[connection signal="pressed" from="SingleplayerMultiplayerContainer/HBoxWebRTC/WebRTC" to="." method="_on_web_rtc_pressed"]
 [connection signal="pressed" from="MultiplayerContainer/Host" to="." method="_on_host_pressed"]
 [connection signal="pressed" from="MultiplayerContainer/Join" to="." method="_on_join_pressed"]
+[connection signal="resolved_as_necessary" from="NetworkGateway" to="." method="_on_network_gateway_resolved_as_necessary"]
+[connection signal="webrtc_multiplayerpeer_set" from="NetworkGateway" to="." method="_on_network_gateway_webrtc_multiplayerpeer_set"]

--- a/scenes/golfball.tscn
+++ b/scenes/golfball.tscn
@@ -140,8 +140,8 @@ mass = 0.05
 physics_material_override = SubResource("PhysicsMaterial_4yvvj")
 can_sleep = false
 freeze = true
-max_contacts_reported = 8
 contact_monitor = true
+max_contacts_reported = 8
 linear_damp = 1.0
 script = ExtResource("5_dceiy")
 

--- a/scripts/gui/character_customization.gd
+++ b/scripts/gui/character_customization.gd
@@ -47,4 +47,3 @@ func set_status(status):
 	else:
 		remove_child(customization_container)
 		add_child(customize_button)
-


### PR DESCRIPTION
Work in progress.

I am creating an addon to manage peer-to-peer WebRTC networking with minimal configuration, and have hacked your project as an exemplar.  The addon is copied from [this version](https://github.com/goatchurchprime/godot_multiplayer_networking_workbench/commit/a357e09059c11bd5bd18e9ff291e71331fd35415) of player-networking (also attached as [player-networking.zip](https://github.com/user-attachments/files/16840746/player-networking.zip))

Further prerequisites from the AssetLib:

* MQTT CLient Version: 1.2 installs into addons/mqtt
* WebRTC plugin - Godot 4.1+ Version: 1.0.6, !!install into addons/webrtc

The design difficulty in my plugin is that the following function executes immediately because the `enet_peer` has a `multiplayer.get_unique_id()` value before the connection is made.  

```GDScript
func _on_join_pressed():
	hide()
	enet_peer.create_client(ip_line_edit.text if ip_line_edit.text else "127.0.0.1", PORT)
	multiplayer.multiplayer_peer = enet_peer
	add_player(multiplayer.get_unique_id())
	Global.set_multiplayer()
```

But in my WebRTC signalling implementation I don't have a `unique_id` until after all the MQTT hand-shaking is done.  For the moment I have added some godot-signals to defer this execution.  